### PR TITLE
Tweak `MatchParen` to have a more sane default

### DIFF
--- a/colors/sublimemonokai.vim
+++ b/colors/sublimemonokai.vim
@@ -144,7 +144,7 @@ hi! link FoldColumn SublimeDarkBlack
 call s:h('Folded',       { 'fg': s:warmgrey,    'bg': s:darkblack                          })
 call s:h('Incsearch',    {                                                                 })
 call s:h('LineNr',       { 'fg': s:grey,        'bg': s:lightblack                         })
-call s:h('MatchParen',   { 'format': 'reverse'                                             })
+call s:h('MatchParen',   { 'fg': s:black,       'bg': s:grey                               })
 hi! link ModeMsg SublimeYellow
 hi! link MoreMsg SublimeYellow
 hi! link NonText SublimeLightGrey

--- a/colors/sublimemonokai.vim
+++ b/colors/sublimemonokai.vim
@@ -144,6 +144,8 @@ hi! link FoldColumn SublimeDarkBlack
 call s:h('Folded',       { 'fg': s:warmgrey,    'bg': s:darkblack                                  })
 call s:h('Incsearch',    {                                                                         })
 call s:h('LineNr',       { 'fg': s:grey,        'bg': s:lightblack                                 })
+" Variation: This looks really nice when made { 'format': 'reverse' } in gVim
+" -- it only works because gVim can control the color of the cursor.
 call s:h('MatchParen',   { 'fg': s:black,       'bg': s:grey,                                      })
 hi! link ModeMsg SublimeYellow
 hi! link MoreMsg SublimeYellow

--- a/colors/sublimemonokai.vim
+++ b/colors/sublimemonokai.vim
@@ -146,7 +146,7 @@ call s:h('Incsearch',    {                                                      
 call s:h('LineNr',       { 'fg': s:grey,        'bg': s:lightblack                                 })
 " Variation: This looks really nice when made { 'format': 'reverse' } in gVim
 " -- it only works because gVim can control the color of the cursor.
-call s:h('MatchParen',   { 'fg': s:black,       'bg': s:grey,                                      })
+call s:h('MatchParen',   { 'fg': s:white,       'bg': s:grey                                       })
 hi! link ModeMsg SublimeYellow
 hi! link MoreMsg SublimeYellow
 hi! link NonText SublimeLightGrey

--- a/colors/sublimemonokai.vim
+++ b/colors/sublimemonokai.vim
@@ -129,42 +129,42 @@ call s:h('SublimeDarkRed',     { 'fg': s:darkred      })
 
 " Default highlight groups (see ':help highlight-default' or http://vimdoc.sourceforge.net/htmldoc/syntax.html#highlight-groups)
 
-call s:h('ColorColumn',  { 'bg': s:lightblack2                                             })
+call s:h('ColorColumn',  {                      'bg': s:lightblack2                                })
 hi! link Conceal SublimeLightGrey
-call s:h('CursorColumn', { 'bg': s:lightblack2                                             })
-call s:h('CursorLine',   { 'bg': s:lightblack2                                             })
-call s:h('CursorLineNr', { 'fg': s:orange,      'bg': s:lightblack                         })
-call s:h('DiffAdd',      { 'fg': s:addfg,       'bg': s:addbg                              })
-call s:h('DiffChange',   { 'fg': s:changefg,    'bg': s:changebg                           })
-call s:h('DiffDelete',   { 'fg': s:black,       'bg': s:delbg                              })
-call s:h('DiffText',     { 'fg': s:black,       'bg': s:aqua                               })
+call s:h('CursorColumn', {                      'bg': s:lightblack2                                })
+call s:h('CursorLine',   {                      'bg': s:lightblack2                                })
+call s:h('CursorLineNr', { 'fg': s:orange,      'bg': s:lightblack                                 })
+call s:h('DiffAdd',      { 'fg': s:addfg,       'bg': s:addbg                                      })
+call s:h('DiffChange',   { 'fg': s:changefg,    'bg': s:changebg                                   })
+call s:h('DiffDelete',   { 'fg': s:black,       'bg': s:delbg                                      })
+call s:h('DiffText',     { 'fg': s:black,       'bg': s:aqua                                       })
 hi! link Directory SublimeAqua
-call s:h('ErrorMsg',     { 'fg': s:black,       'bg': s:red,      'format': 'standout'     })
+call s:h('ErrorMsg',     { 'fg': s:black,       'bg': s:red,         'format': 'standout'          })
 hi! link FoldColumn SublimeDarkBlack
-call s:h('Folded',       { 'fg': s:warmgrey,    'bg': s:darkblack                          })
-call s:h('Incsearch',    {                                                                 })
-call s:h('LineNr',       { 'fg': s:grey,        'bg': s:lightblack                         })
-call s:h('MatchParen',   { 'fg': s:black,       'bg': s:grey                               })
+call s:h('Folded',       { 'fg': s:warmgrey,    'bg': s:darkblack                                  })
+call s:h('Incsearch',    {                                                                         })
+call s:h('LineNr',       { 'fg': s:grey,        'bg': s:lightblack                                 })
+call s:h('MatchParen',   { 'fg': s:black,       'bg': s:grey,                                      })
 hi! link ModeMsg SublimeYellow
 hi! link MoreMsg SublimeYellow
 hi! link NonText SublimeLightGrey
-call s:h('Normal',       { 'fg': s:white,       'bg': s:black                              })
-call s:h('Pmenu',        { 'fg': s:lightblack,  'bg': s:white                              })
-call s:h('PmenuSbar',    {                                                                 })
-call s:h('PmenuSel',     { 'fg': s:aqua,        'bg': s:black,    'format': 'reverse,bold' })
-call s:h('PmenuThumb',   { 'fg': s:lightblack,  'bg': s:grey                               })
+call s:h('Normal',       { 'fg': s:white,       'bg': s:black                                      })
+call s:h('Pmenu',        { 'fg': s:lightblack,  'bg': s:white                                      })
+call s:h('PmenuSbar',    {                      'bg': s:lightgrey                                  })
+call s:h('PmenuSel',     { 'fg': s:aqua,        'bg': s:black,       'format': 'reverse,bold'      })
+call s:h('PmenuThumb',   { 'fg': s:lightblack,  'bg': s:grey                                       })
 hi! link Question SublimeYellow
-call s:h('Search',       { 'format': 'reverse,underline'                                   })
+call s:h('Search',       {                                           'format': 'reverse,underline' })
 hi! link SignColumn SublimeLightBlack
 hi! link SpecialKey SublimeLightBlack2
-call s:h('StatusLine',   { 'fg': s:warmgrey,    'bg': s:black,    'format': 'reverse'      })
-call s:h('StatusLineNC', { 'fg': s:darkgrey,    'bg': s:warmgrey, 'format': 'reverse'      })
-call s:h('TabLine',      { 'fg': s:white,       'bg': s:darkgrey                           })
-call s:h('TabLineFill',  { 'fg': s:grey,        'bg': s:darkgrey                           })
-call s:h('TabLineSel',   { 'fg': s:brightwhite, 'bg': s:white                              })
+call s:h('StatusLine',   { 'fg': s:warmgrey,    'bg': s:black,       'format': 'reverse'           })
+call s:h('StatusLineNC', { 'fg': s:darkgrey,    'bg': s:warmgrey,    'format': 'reverse'           })
+call s:h('TabLine',      { 'fg': s:white,       'bg': s:darkgrey                                   })
+call s:h('TabLineFill',  { 'fg': s:grey,        'bg': s:darkgrey                                   })
+call s:h('TabLineSel',   { 'fg': s:brightwhite, 'bg': s:white                                      })
 hi! link Title SublimeYellow
-call s:h('VertSplit',    { 'fg': s:darkgrey,    'bg': s:darkblack                          })
-call s:h('Visual',       { 'bg': s:lightgrey                                               })
+call s:h('VertSplit',    { 'fg': s:darkgrey,    'bg': s:darkblack                                  })
+call s:h('Visual',       {                      'bg': s:lightgrey                                  })
 hi! link WarningMsg SublimeRed
 
 " Generic Syntax Highlighting (see reference: 'NAMING CONVENTIONS' at http://vimdoc.sourceforge.net/htmldoc/syntax.html#group-name)


### PR DESCRIPTION
When in terminal `vim`, the `reverse`-only highlight doesn't look awesome. Most consoles by default render the cursor as white-on-black, which can make the cursor location hard to see when on matched enclosing characters like a parenthesis or a bracket. Make `MatchParen` to be black-on-grey as an experiment intended to resolve #1 (CC: @ricochet1k). 

There are a number of complicating factors with this problem space that make it so that we really can only use a set background/foreground color combination as the default:

1. Terminal emulators generally are responsible for rendering the cursor and therefore do it LAST, changing the foreground and background AFTER `vim` has set colors.
    * Interestingly, most emulators won't force `reverse` formatting to be off when rendering the cursor, which means that if we use `reverse` in `MatchParen` like we did previously then it will invert whatever the emulator tries to render for the cursor later. This is the issue that @ricochet1k saw in #1, since until now `MatchParen` has only been `{ 'format': 'reverse' }`.
2. Graphical Vim implementations take responsibility of rendering the cursor into Vim's own highlighting system, with the `Cursor` and `CursorIME` groups controlling the vast majority of the cursor's color. 
    * When placed on an enclosing character, Graphical Vim *alternates* the application of `MatchParen` and the appropriate `Cursor*` highlight group, which means that `reverse` formatting works just fine here. Doing something like this in my `vimrc` actually looks nice:

        ```viml
        if has('gui_running')
            call g:SublimeMonokaiHighlight('MatchParen', { 'format': 'reverse' })
        endif
        ```