### PR TITLE
added color for pythonFunctionCall

### DIFF
--- a/colors/sublimemonokai.vim
+++ b/colors/sublimemonokai.vim
@@ -909,6 +909,7 @@ hi! link pythonConditional        Conditional
 hi! link pythonException          Keyword
 hi! link pythonExClass            SublimeType
 hi! link pythonFunction           Tag
+hi! link pythonFunctionCall       SublimeFunctionCall
 hi! link pythonImport             Keyword
 hi! link pythonInclude            Keyword
 hi! link pythonLambdaExpr         SublimeType


### PR DESCRIPTION
This commit fixes issues with python highlighting functions and methods. On the left default behavior, on the right the new one.
<img width="1422" alt="Снимок экрана 2024-11-01 в 18 25 39" src="https://github.com/user-attachments/assets/0143caed-f8e0-43d0-b767-bcaf03f6e1cc">

P. S. I've tried to fix highlighting using this [issue](https://github.com/ErichDonGubler/vim-sublime-monokai/issues/7), but it didn't help.