### PR TITLE
Add g:sublimemonokai_transparent_bg to allow for a transparent background

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ to your `.vimrc`:
 let g:sublimemonokai_term_italic = 1
 ```
 
+### Transparent background
+
+To use a transparent background, add the following to your `.vimrc`:
+
+```viml
+let g:sublimemonokai_transparent_bg = 1
+```
+
 ## Language-specific configuration
 
 In order to provide an experience with parity to Sublime, this color scheme

--- a/colors/sublimemonokai.vim
+++ b/colors/sublimemonokai.vim
@@ -21,6 +21,10 @@ if !exists('g:sublimemonokai_term_italic')
 	let g:sublimemonokai_term_italic = 0
 endif
 
+if !exists('g:sublimemonokai_transparent_bg')
+	let g:sublimemonokai_transparent_bg = 0
+endif
+
 let g:sublimemonokai_termcolors = 256 " does not support 16 color term right now.
 
 set background=dark
@@ -100,6 +104,7 @@ call s:create_palette_color('orange',      { 'gui': '#fd9720', 'cterm': '208' })
 call s:create_palette_color('purple',      { 'gui': '#ae81ff', 'cterm': '141' })
 call s:create_palette_color('red',         { 'gui': '#e73c50', 'cterm': '196' })
 call s:create_palette_color('darkred',     { 'gui': '#5f0000', 'cterm': '52'  })
+call s:create_palette_color('none',        { 'gui': 'NONE',    'cterm': 'NONE'})
 
 call s:create_palette_color('addfg',       { 'gui': '#d7ffaf', 'cterm': '193' })
 call s:create_palette_color('addbg',       { 'gui': '#5f875f', 'cterm': '65'  })
@@ -153,7 +158,7 @@ call s:h('MatchParen',   {                                        'format': 'und
 hi! link ModeMsg SublimeYellow
 hi! link MoreMsg SublimeYellow
 hi! link NonText SublimeLightGrey
-call s:h('Normal',       { 'fg': s:white,       'bg': s:black                                  })
+call s:h('Normal',       { 'fg': s:white,       'bg': g:sublimemonokai_transparent_bg  ? s:none : s:black})
 if has('nvim')
 	call s:h('NormalFloat',{ 'fg': s:white,       'bg': s:warmgrey                               })
 end


### PR DESCRIPTION
When adding this option, the background color will be none, allowing the color to be whatever the terminal background is. I liked this option in [dracula.vim](https://github.com/dracula/vim) (they use `g:dracula_colorterm`) and thought it would be a good addition to this colorscheme. I noticed dracula also makes the background transparent if the GUI is running, so I can add this as well if this is desired.

Also, I can definitely reformat the file to have the braces (`})`) lined up if this is wanted.